### PR TITLE
fix compile errors on stock Windows 10 .NET framework

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -238,7 +238,7 @@ namespace Closhure
             }
             else if (value is char)
             {
-                switch (value)
+                switch ((char)value)
                 {
                     case '\n': return "\\newline";
                     case ' ': return "\\space";
@@ -411,7 +411,8 @@ namespace Closhure
                     }
                     return macroexpand(newForm);
                 }
-                if (prefix is Symbol && macros.TryGetValue(ps, out UserFn func))
+                UserFn func;
+                if (prefix is Symbol && macros.TryGetValue(ps, out func))
                 {
                     // build arguments
                     List<object> args = new List<object>();
@@ -1060,7 +1061,8 @@ namespace Closhure
         // cached. throws if not found.
         internal static Type getClass(string className)
         {
-            if (getClassCache.TryGetValue(className, out Type s))
+            Type s;
+            if (getClassCache.TryGetValue(className, out s))
             {
                 return s;
             }


### PR DESCRIPTION
I don't know much about C# or .NET and I don't have any SDK installed. I'm on Windows 10, and I just added C:\Windows\Microsoft.NET\Framework64\v4.0.30319 to my PATH.

After cloning your repo "msbuild" failed, the changes in this PR make the build succeed and simple froms entered into the REPL seem to work.

TBH I don't really know what I'm doing as this is my first "C# coding" so take all of this with a grain of salt (and/ or ignore this PR) :-D

That said, I think your Lisp is kinda cool and I think it would be great if people could build and use it with just a stock Windows 10 install, w/o the need to install anything else.

You may also want to consider amending your README.md with build instructions such as

Have Windows 10
do "PATH=C:\Windows\Microsoft.NET\Framework64\v4.0.30319;%PATH"
clone the repo
cd Closhure
msbuild

or something like that.

Cheers!